### PR TITLE
Fix occassional build error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptonica-plumbing"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Chris Couzens <ccouzens@gmail.com>"]
 edition = "2018"
 description = "Safe wrapper of `leptonica-sys`"

--- a/src/pix.rs
+++ b/src/pix.rs
@@ -3,7 +3,7 @@ use leptonica_sys::{
 };
 
 use crate::memory::{LeptonicaClone, LeptonicaDestroy, RefCountedExclusive};
-use std::convert::{AsRef, TryInto};
+use std::convert::{AsRef, Infallible, TryInto};
 use std::{ffi::CStr, num::TryFromIntError};
 use thiserror::Error;
 
@@ -18,6 +18,12 @@ pub enum PixReadMemError {
     NullPtr,
     #[error("Failed to convert image size")]
     ImageSizeConversion(#[from] TryFromIntError),
+}
+
+impl From<Infallible> for PixReadMemError {
+    fn from(_: Infallible) -> Self {
+        unreachable!()
+    }
 }
 
 /// Error returned by Pix::read


### PR DESCRIPTION
As documented here
https://github.com/dtolnay/thiserror/issues/62

Sometimes I'd get a build failure
For example here
https://github.com/antimatter15/tesseract-rs/actions/runs/4275328902/jobs/7442596787

```
error[E0277]: `?` couldn't convert the error to `PixReadMemError`
  --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/leptonica-plumbing-1.0.0/src/pix.rs:68:73
   |
68 |         let ptr = unsafe { pixReadMem(img.as_ptr(), img.len().try_into()?) };
   |                                                                         ^ the trait `From<Infallible>` is not implemented for `PixReadMemError`
   |
   = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
   = help: the trait `From<TryFromIntError>` is implemented for `PixReadMemError`
   = note: required for `Result<RefCountedExclusive<pix::Pix>, PixReadMemError>` to implement `FromResidual<Result<Infallible, Infallible>>`
```

It seems hit and miss to if it's needed or not, which is why I didn't immedaitely pick up on it.

https://tpgit.github.io/Leptonica/leptprotos_8h.html#a027a927dc3438192e3bdae8c219d7f6a

`pixReadMem` has the parameter defined as `size_t`, so it should be automatically compatible with `usize`.