### PR TITLE
Add `read_with_hint` and `scale_general`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptonica-plumbing"
-version = "1.3.0"
+version = "1.4.0"
 authors = ["Chris Couzens <ccouzens@gmail.com>"]
 edition = "2018"
 description = "Safe wrapper of `leptonica-sys`"

--- a/src/pix.rs
+++ b/src/pix.rs
@@ -1,6 +1,6 @@
 use leptonica_sys::{
-    l_int32, l_uint32, pixClone, pixDestroy, pixGetData, pixGetDepth, pixGetHeight, pixGetWidth,
-    pixRead, pixReadMem, pixReadWithHint,
+    l_float32, l_int32, l_uint32, pixClone, pixDestroy, pixGetData, pixGetDepth, pixGetHeight,
+    pixGetWidth, pixRead, pixReadMem, pixReadWithHint, pixScaleGeneral, pixTransferAllData,
 };
 
 use crate::memory::{LeptonicaClone, LeptonicaDestroy, RefCountedExclusive};
@@ -31,6 +31,14 @@ impl From<Infallible> for PixReadMemError {
 #[derive(Debug, Error)]
 #[error("Pix::read returned null")]
 pub struct PixReadError();
+
+#[derive(Debug, Error, PartialEq)]
+pub enum PixManipError {
+    #[error("some internal data moving failed")]
+    PixInternalError,
+    #[error("Pix scaling returned null")]
+    PixScaleError,
+}
 
 impl AsRef<*mut leptonica_sys::Pix> for Pix {
     fn as_ref(&self) -> &*mut leptonica_sys::Pix {
@@ -107,6 +115,34 @@ impl Pix {
             Err(PixReadError())
         } else {
             Ok(unsafe { RefCountedExclusive::new(Self(ptr)) })
+        }
+    }
+
+    fn pix_transfer_data(
+        &mut self,
+        ptr: &mut *mut leptonica_sys::Pix,
+    ) -> Result<(), PixManipError> {
+        let result = unsafe { pixTransferAllData(self.0, ptr, 0, 0) };
+        if result != 0 {
+            Err(PixManipError::PixInternalError)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Wrapper for [`pixScaleGeneral`](https://tpgit.github.io/Leptonica/leptprotos_8h.html#a2f8ea34f3d02024f5d42ca05d2961177)
+    pub fn scale_general(
+        &mut self,
+        scalex: l_float32,
+        scaley: l_float32,
+    ) -> Result<(), PixManipError> {
+        let sharpwidth = if scalex.max(scaley) < 0.7 { 1 } else { 2 };
+        let mut ptr = unsafe { pixScaleGeneral(self.0, scalex, scaley, 0.0, sharpwidth) };
+        if ptr.is_null() {
+            Err(PixManipError::PixScaleError)
+        } else {
+            self.pix_transfer_data(&mut ptr)?;
+            Ok(())
         }
     }
 


### PR DESCRIPTION
In one of my [projects](https://github.com/bepvte/ocrlocate), I need to read tons of different JPEG files from the internet, some of which make leptonica complain and give up, so I added [`pixReadWithHint`](https://tpgit.github.io/Leptonica/leptprotos_8h.html#a3ce88fc6a624a5c5c2f698f49db1d8a5) 

I also wanted to experiment with different leptonica scaling functions and sharpness and their performance when applied before OCR, and ended up using [`pixScaleGeneral`](https://tpgit.github.io/Leptonica/leptprotos_8h.html#a2f8ea34f3d02024f5d42ca05d2961177) so I can downscale without sharpening, which sped up my usecase slightly.

Just wanted to upstream these changes, if anything is out of place let me know.